### PR TITLE
Fix math and JS minification

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -59,7 +59,7 @@ css_bundle_style('light')
 css_bundle_style('dark')
 
 # JS
-js = Bundle('js/main.js', filters=('browserify'), output='lib/main.js')
+js = Bundle('js/main.js', filters=('browserify', 'uglifyjs'), output='lib/main.js')
 
 uglify_args = ['-m', '--mange-props', 'regex=/^_.+$/', '-c']
 

--- a/misc/markdown-renderer.js
+++ b/misc/markdown-renderer.js
@@ -1,6 +1,6 @@
 var MarkdownIt = require('markdown-it'),
     KaTeX = require('katex'),
-    tm = require('markdown-it-texmath').use(KaTeX),
+    mk = require('markdown-it-math-katex'),
     hljs = require('highlight.js'),
     footnote = require('markdown-it-footnote'),
     mila = require('markdown-it-link-attributes');
@@ -25,8 +25,9 @@ var md = new MarkdownIt({
 
         return '<pre class="hljs' + langExec + '"><code>' + md.utils.escapeHtml(string) + '</code></pre>';
     }
-}).use(tm, {
-    delimiters: 'dollars'
+}).use(mk, {
+    throwOnError: false,
+    errorColor: "#F00"
 }).use(mila, {
     attrs: {
         target: '_blank',

--- a/misc/markdown-renderer.js
+++ b/misc/markdown-renderer.js
@@ -1,5 +1,4 @@
 var MarkdownIt = require('markdown-it'),
-    KaTeX = require('katex'),
     mk = require('markdown-it-math-katex'),
     hljs = require('highlight.js'),
     footnote = require('markdown-it-footnote'),

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "envify": "^4.1.0",
     "escape-html": "^1.0.3",
     "highlight.js": "^9.12.0",
-    "katex": "^0.9.0-beta1",
     "markdown-it": "^8.4.0",
     "markdown-it-footnote": "^3.0.1",
     "markdown-it-link-attributes": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "markdown-it": "^8.4.0",
     "markdown-it-footnote": "^3.0.1",
     "markdown-it-link-attributes": "^2.0.0",
-    "markdown-it-texmath": "^0.4.7",
-    "n": "^2.1.8",
+    "markdown-it-math-katex": "^2.0.3",
     "progress": "^2.0.0",
     "uglify-js": "^3.3.4"
   }


### PR DESCRIPTION
Adds JS minification which cuts file size by about 48%. Also looks like I was too quick to choose a math rendering library (which happened to only support latest browsers) so I just made a fork.

Since math rendering is server side (except for previews), do we want to continue using KaTeX (significantly faster) or do we want to use MathJax (much slower but more features).

Signed-off-by: Vihan <contact@vihan.org>